### PR TITLE
two videos at the same time

### DIFF
--- a/philosophy.html
+++ b/philosophy.html
@@ -41,7 +41,7 @@
     </section>
     <section class="philosophy__poetry5">
         <div class="gary__philosophy5">
-            <iframe width="70" height="40" src="https://www.youtube.com/embed/RGdcbD-sNvE?controls=0"
+            <iframe width="70" height="40" src="https://www.youtube.com/embed/RGdcbD-sNvE?controls=0&autoplay=1&mute=0"
                 title="YouTube video player" frameborder="0"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
             <h4>Drinking your own blood is the paradigm of recycling.</h4>


### PR DESCRIPTION
This change should play two videos at the same time on the philosophy page.

To Test:
1. Open in Chrome.
2. Navigate to the philosophy page
3. Verify that both videos begin playing automatically.
4. Check the html code to confirm that the src has autoplay=1&mute=0 at the end.